### PR TITLE
Add JUnit and unit tests for VariableLengthInt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,20 @@
 
     <groupId>com.github.leffelmania</groupId>
     <artifactId>android-midi-lib</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.5</maven.compiler.source>
-        <maven.compiler.target>1.5</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/com/leff/midi/util/VariableLengthInt.java
+++ b/src/main/java/com/leff/midi/util/VariableLengthInt.java
@@ -19,6 +19,32 @@ package com.leff.midi.util;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * From the official "Standard MIDI File" specification:
+ * <p>
+ * Some numbers in MIDI Files are represented in
+ * a form called a variable-length quantity. These numbers are represented 7 bits per byte, most significant
+ * bits first. All bytes except the last have bit 7 (the most significant bit) set, and the last byte has bit
+ * 7 clear. If the number is between 0 and 127, it is thus represented exactly as one byte.
+ * <p>
+ * Here are some examples of numbers represented as variable-length quantities:
+ * <p>
+ * Number (hex) = Representation (hex)<br>
+ * <code>00 00 00 00 = 00 </code><br>
+ * <code>00 00 00 40 = 40 </code><br>
+ * <code>00 00 00 7F = 7F </code><br>
+ * <code>00 00 00 80 = 81 00 </code><br>
+ * <code>00 00 20 00 = C0 00 </code><br>
+ * <code>00 00 3F FF = FF 7F </code><br>
+ * <code>00 00 40 00 = 81 80 00 </code><br>
+ * <code>00 10 00 00 = C0 80 00 </code><br>
+ * <code>00 1F FF FF = FF FF 7F </code><br>
+ * <code>00 20 00 00 = 81 80 80 00 </code><br>
+ * <code>08 00 00 00 = C0 80 80 00 </code><br>
+ * <code>0F FF FF FF = FF FF FF 7F </code><br>
+ * <p>
+ * The largest number which is allowed is 0FFFFFFF 
+ */
 public class VariableLengthInt
 {
     private int mValue;
@@ -75,7 +101,7 @@ public class VariableLengthInt
                 ints[mSizeInBytes - 1] = (b & 0x7F);
                 break;
             }
-            ints[mSizeInBytes - 1] = (b & 0x7F);
+            ints[mSizeInBytes - 1] = (b & 0xFF);
 
             b = in.read();
         }
@@ -90,7 +116,7 @@ public class VariableLengthInt
         {
             mBytes[i] = (byte) ints[i];
 
-            mValue += ints[i] << shift;
+            mValue += (ints[i] & 0x7F) << shift;
             shift -= 7;
         }
     }

--- a/src/test/java/com/leff/midi/util/TestVariableLengthInt.java
+++ b/src/test/java/com/leff/midi/util/TestVariableLengthInt.java
@@ -1,0 +1,177 @@
+package com.leff.midi.util;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import static org.junit.Assert.*;
+
+public class TestVariableLengthInt
+{
+    @Test
+    public void testMinimumOneByteValueFromInt() {
+        VariableLengthInt vli = new VariableLengthInt(0x00);
+        assertEquals(0x00, vli.getValue());
+        assertEquals(1, vli.getByteCount());
+        assertArrayEquals(new byte[] { 0x00 }, vli.getBytes());
+    }
+    
+    @Test
+    public void testMinimumOneByteValueFromStream() throws Exception {
+        InputStream stream = new ByteArrayInputStream(new byte[] { 0x00 });
+        VariableLengthInt vli = new VariableLengthInt(stream);
+        assertEquals(0x00, vli.getValue());
+        assertEquals(1, vli.getByteCount());
+        assertArrayEquals(new byte[] { 0x00 }, vli.getBytes());
+    }
+    
+    @Test
+    public void testMaximumOneByteValueFromInt() {
+        VariableLengthInt vli = new VariableLengthInt(0x7F);
+        assertEquals(0x7F, vli.getValue());
+        assertEquals(1, vli.getByteCount());
+        assertArrayEquals(new byte[] { 0x7F }, vli.getBytes());
+    }
+
+    @Test
+    public void testMaximumOneByteValueFromStream() throws Exception {
+        InputStream stream = new ByteArrayInputStream(new byte[] {0x7F});
+        VariableLengthInt vli = new VariableLengthInt(stream);
+        assertEquals(0x7F, vli.getValue());
+        assertEquals(1, vli.getByteCount());
+        assertArrayEquals(new byte[] { 0x7F }, vli.getBytes());
+    }
+    
+    @Test
+    public void testMinimumTwoByteValueFromInt() {
+        VariableLengthInt vli = new VariableLengthInt(0x80);
+        assertEquals(0x80, vli.getValue());
+        assertEquals(2, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0x81, 0x00 }, vli.getBytes());
+    }
+
+    @Test
+    public void testMinimumTwoByteValueFromStream() throws Exception {
+        InputStream stream = new ByteArrayInputStream(new byte[] { (byte) 0x81, 0x00 });
+        VariableLengthInt vli = new VariableLengthInt(stream);
+        assertEquals(0x80, vli.getValue());
+        assertEquals(2, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0x81, 0x00 }, vli.getBytes());
+    }
+    
+    @Test
+    public void testMaximumTwoByteValueFromInt() {
+        VariableLengthInt vli = new VariableLengthInt(0x3F_FF);
+        assertEquals(0x3F_FF, vli.getValue());
+        assertEquals(2, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0xFF, 0x7F }, vli.getBytes());
+    }
+    
+    @Test
+    public void testMaximumTwoByteValueFromStream() throws Exception {
+        InputStream stream = new ByteArrayInputStream(new byte[] { (byte) 0xFF, 0x7F });
+        VariableLengthInt vli = new VariableLengthInt(stream);
+        assertEquals(0x3F_FF, vli.getValue());
+        assertEquals(2, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0xFF, 0x7F }, vli.getBytes());
+    }
+    
+    @Test
+    public void testMinimumThreeByteValueFromInt() {
+        VariableLengthInt vli = new VariableLengthInt(0x40_00);
+        assertEquals(0x40_00, vli.getValue());
+        assertEquals(3, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0x81, (byte) 0x80, 0x00 }, vli.getBytes());
+    }
+
+    @Test
+    public void testMinimumThreeByteValueFromStream() throws Exception {
+        InputStream stream = new ByteArrayInputStream(new byte[] { (byte) 0x81, (byte) 0x80, 0x00 });
+        VariableLengthInt vli = new VariableLengthInt(stream);
+        assertEquals(0x40_00, vli.getValue());
+        assertEquals(3, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0x81, (byte) 0x80, 0x00 }, vli.getBytes());
+    }
+    
+    @Test
+    public void testMaximumThreeByteValueFromInt() {
+        VariableLengthInt vli = new VariableLengthInt(0x1F_FF_FF);
+        assertEquals(0x1F_FF_FF, vli.getValue());
+        assertEquals(3, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0xFF, (byte) 0xFF, 0x7F }, vli.getBytes());
+    }
+
+    @Test
+    public void testMaximumThreeByteValueFromStream() throws Exception {
+        InputStream stream = new ByteArrayInputStream(new byte[] { (byte) 0xFF, (byte) 0xFF, 0x7F });
+        VariableLengthInt vli = new VariableLengthInt(stream);
+        assertEquals(0x1F_FF_FF, vli.getValue());
+        assertEquals(3, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0xFF, (byte) 0xFF, 0x7F }, vli.getBytes());
+    }
+    
+    @Test
+    public void testMinimumFourByteValueFromInt() {
+        VariableLengthInt vli = new VariableLengthInt(0x20_00_00);
+        assertEquals(0x20_00_00, vli.getValue());
+        assertEquals(4, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0x81, (byte) 0x80, (byte) 0x80, 0x00 }, vli.getBytes());
+    }
+
+    @Test
+    public void testMinimumFourByteValueFromStream() throws Exception {
+        InputStream stream = new ByteArrayInputStream(new byte[] { (byte) 0x81, (byte) 0x80, (byte) 0x80, 0x00 });
+        VariableLengthInt vli = new VariableLengthInt(stream);
+        assertEquals(0x20_00_00, vli.getValue());
+        assertEquals(4, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0x81, (byte) 0x80, (byte) 0x80, 0x00 }, vli.getBytes());
+    }
+    
+    @Test
+    public void testMaximumFourByteValueFromInt() {
+        VariableLengthInt vli = new VariableLengthInt(0x0F_FF_FF_FF);
+        assertEquals(0x0F_FF_FF_FF, vli.getValue());
+        assertEquals(4, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x7F }, vli.getBytes());
+    }
+
+    @Test
+    public void testMaximumFourByteValueFromStream() throws Exception {
+        InputStream stream = new ByteArrayInputStream(new byte[] { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x7F });
+        VariableLengthInt vli = new VariableLengthInt(stream);
+        assertEquals(0x0F_FF_FF_FF, vli.getValue());
+        assertEquals(4, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x7F }, vli.getBytes());
+    }
+    
+    @Test
+    public void testSetValue() {
+        VariableLengthInt vli = new VariableLengthInt(0);
+        
+        vli.setValue(0x40);
+        assertEquals(0x40, vli.getValue());
+        assertEquals(1, vli.getByteCount());
+        assertArrayEquals(new byte[] { 0x40 }, vli.getBytes());
+        
+        vli.setValue(0x08_00_00_00);
+        assertEquals(0x08_00_00_00, vli.getValue());
+        assertEquals(4, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0xC0, (byte) 0x80, (byte) 0x80, 0x00 }, vli.getBytes());
+     
+        vli.setValue(0x20_00);
+        assertEquals(0x20_00, vli.getValue());
+        assertEquals(2, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0xC0, 0x00 }, vli.getBytes());
+
+        vli.setValue(0x10_00_00);
+        assertEquals(0x10_00_00, vli.getValue());
+        assertEquals(3, vli.getByteCount());
+        assertArrayEquals(new byte[] { (byte) 0xC0, (byte) 0x80, 0x00 }, vli.getBytes());
+    }
+    
+    @Test
+    public void testToString() {
+        assertEquals("00  (0)", new VariableLengthInt(0).toString());
+        assertEquals("8F FF FF 7F  (33554431)", new VariableLengthInt(0x01_FF_FF_FF).toString());
+    }
+}


### PR DESCRIPTION
I came across this library as something I might use in an android app needing MIDI support. At some point I started digging into the library to debug some problems in my own code and was puzzled by a few things, especially VariableLengthInt. I thought it might be instructive to write some tests for it to run through some use cases and figure out what it was doing. And, of course, perhaps it would end up something I could contribute back to the library. Maybe, unlikely as it may be, someone else who is in my shoes down the road will look for unit tests as a form of documentation (as I sometimes do).

Eventually, I became overwhelmed by the oddities of how midi file creation logic seemed to be implemented and had to dig into the official specs. That cleared up a lot haha.

I went ahead and rounded out the test suite I had started and in the process, found a small inconsistency in how VariableLengthInt stores state. I went ahead and fixed that in this PR along with the test suite, but could also split the changes into multiple PR's if that feels like a better approach.

Here's a description of the inconsistency:
Seems like (without the commit in this PR) when a VariableLengthInt object is created with the stream constructor, it doesn't store the bytes as they are read from the stream: it [removes the most significant digit](https://github.com/LeffelMania/android-midi-lib/blob/7cdd855c2b70d2074a53732e8a3979fe8e65e12a/src/main/java/com/leff/midi/util/VariableLengthInt.java#L78) so that [integer math](https://github.com/LeffelMania/android-midi-lib/blob/7cdd855c2b70d2074a53732e8a3979fe8e65e12a/src/main/java/com/leff/midi/util/VariableLengthInt.java#L93) is correct later. The int constructor, on the other hand,  *does* store the bytes with the most significant bits set to properly represent a variable length quantity (all bytes have a 1 in their MSB except for the last byte which has a 0). This is likely (hopefully) not an issue for anyone. By searching some reference chains in my IDE, it seems like `VariableLengthInt.getBytes()` only ever really gets called in two situations:
1) by MetaData objects storing data length
2) by MidiTrack objects storing delta time values

The first situation likely is not an issue because the length of the data seems to be always gotten from the length of a byte array (hence using the int constructor of VariableLengthInt). The second situation shouldn't be an issue because [the event parsing code throws away the VariableLengthInt object](https://github.com/LeffelMania/android-midi-lib/blob/7cdd855c2b70d2074a53732e8a3979fe8e65e12a/src/main/java/com/leff/midi/MidiTrack.java#L100) that it creates after reading from the stream and only passes in the integer value to the function signature that expects a long for the delta. That long seems to inevitably get passed up the hierarchy chain to MidiEvent, which finally [passes it to the VariableLengthInt's int constructor](https://github.com/LeffelMania/android-midi-lib/blob/7cdd855c2b70d2074a53732e8a3979fe8e65e12a/src/main/java/com/leff/midi/event/MidiEvent.java#L34). So, unless I'm missing something, all code paths that get bytes from a VariableLengthInt involve objects created with the int constructor. However, if any 3rd party code is relying on the underlying implementation of VariableLengthInt, this would be a breaking change. I've bumped the version in the pom.xml to 1.1 for good measure, but wouldn't object to a major version bump (doesn't look like there's any release process in place, so hopefully version numbers are cheap :P ).